### PR TITLE
Allow overriding links if server responds with `link` and allow HTTP headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Link Tool supports these configuration parameters:
 | Field    | Type        | Description                                    |
 | ---------|-------------|------------------------------------------------|
 | endpoint | `string`    | **Required:** the endpoint for link data fetching. |
-| headaers | `object`    | **Optional:** the headers used in the GET request. |
+| headers | `object`    | **Optional:** the headers used in the GET request. |
 
 ## Output data
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ const editor = EditorJS({
     linkTool: {
       class: LinkTool,
       config: {
-        endpoint: 'http://localhost:8008/fetchUrl', // Your backend endpoint for url data fetching
+        endpoint: 'http://localhost:8008/fetchUrl', // Your backend endpoint for url data fetching,
       }
     }
   },
@@ -70,6 +70,7 @@ Link Tool supports these configuration parameters:
 | Field    | Type        | Description                                    |
 | ---------|-------------|------------------------------------------------|
 | endpoint | `string`    | **Required:** the endpoint for link data fetching. |
+| headaers | `object`    | **Optional:** the headers used in the GET request. |
 
 ## Output data
 
@@ -107,6 +108,7 @@ Backend response **should** cover following format:
 ```json5
 {
     "success" : 1,
+    "link": "https://codex.so", // Optionally return a link to set the hyperlink URL
     "meta": {
         // ... any fields you want
     }
@@ -114,6 +116,8 @@ Backend response **should** cover following format:
 ```
 
 **success** — uploading status. 1 for successful, 0 for failed
+
+**link** - You are able to return the l
 
 **meta** — link fetched data.
 

--- a/src/index.js
+++ b/src/index.js
@@ -78,6 +78,7 @@ export default class LinkTool {
      */
     this.config = {
       endpoint: config.endpoint || '',
+      headers: config.headers || {},
     };
 
     this.nodes = {
@@ -385,6 +386,7 @@ export default class LinkTool {
     try {
       const { body } = await (ajax.get({
         url: this.config.endpoint,
+        headers: this.config.headers,
         data: {
           url,
         },
@@ -409,6 +411,8 @@ export default class LinkTool {
     }
 
     const metaData = response.meta;
+
+    const link = response.link || this.data.link;
 
     this.data = { meta: metaData };
 

--- a/src/index.js
+++ b/src/index.js
@@ -414,7 +414,10 @@ export default class LinkTool {
 
     const link = response.link || this.data.link;
 
-    this.data = { meta: metaData };
+    this.data = {
+      meta: metaData,
+      link,
+    };
 
     if (!metaData) {
       this.fetchingFailed(this.api.i18n.t('Wrong response format from the server'));


### PR DESCRIPTION
### Summary
This PR contains two additions:
1. Allows user to override the hyperlink URL that is saved. This is especially important to 

**Commit history**
Update src/index.js and README.md - Allow Overriding the link from a server response. Allow using headers in HTTP requests

**Related issues**
#55, #42, #20
