### PR TITLE
Fix/link pastes content on drag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/link",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "keywords": [
     "codex editor",
     "tool",

--- a/src/index.js
+++ b/src/index.js
@@ -111,6 +111,7 @@ export default class LinkTool {
    */
   render() {
     this.nodes.wrapper = this.make('div', this.CSS.baseClass);
+    this.nodes.wrapper.draggable = !this.readOnly;
     this.nodes.container = this.make('div', this.CSS.container);
 
     this.nodes.inputHolder = this.makeInputHolder();
@@ -303,6 +304,7 @@ export default class LinkTool {
     const holder = this.make('a', this.CSS.linkContent, {
       target: '_blank',
       rel: 'nofollow noindex noreferrer',
+      draggable: false,
     });
 
     this.nodes.linkImage = this.make('div', this.CSS.linkImage);


### PR DESCRIPTION
##** What this PR does **
- This PR allows the  link block to be dragged when the editor is setup to allow it
- It prevents the link block pasting its content into the editor when dragged

## **Screenshots**
`Before  this PR`


https://user-images.githubusercontent.com/46571439/191145261-23e6c776-2139-464a-9519-15409c5df39f.mov





`After this PR`


https://user-images.githubusercontent.com/46571439/191145281-b3be2e60-e710-4c82-b1f1-29728313668f.mov




